### PR TITLE
Fix-pronounChecker

### DIFF
--- a/apps/discordbot/src/discord/helper/pronoun-checker.spec.ts
+++ b/apps/discordbot/src/discord/helper/pronoun-checker.spec.ts
@@ -4,4 +4,33 @@ describe('PronounChecker', () => {
   it('should be defined', () => {
     expect(new PronounChecker()).toBeDefined();
   });
+
+  it('Merijn - hij/hem', () => {
+    expect(PronounChecker.checkString('Merijn - hij/hem') ).toBe(true);
+  });
+
+  it('Merijn - hji/hem', () => {
+    expect(PronounChecker.checkString('Merijn - hji/hem') ).toBe(false);
+  });
+
+  it('Merijn - die/diezens', () => {
+    expect(PronounChecker.checkString('Merijn - die/diezens') ).toBe(false);
+  });
+
+  it('Merijn', () => {
+    expect(PronounChecker.checkString('Merijn') ).toBe(false);
+  });
+
+  it('Merijn - E', () => {
+    expect(PronounChecker.checkString('Merijn - E') ).toBe(false);
+  });
+ 
+  it('E', () => {
+    expect(PronounChecker.checkString('E') ).toBe(false);
+  }); 
+
+  it('', () => {
+    expect(PronounChecker.checkString('') ).toBe(false);
+  }); 
+
 });

--- a/apps/discordbot/src/discord/helper/pronoun-checker.ts
+++ b/apps/discordbot/src/discord/helper/pronoun-checker.ts
@@ -16,6 +16,10 @@ export class PronounChecker {
   public static checkString(string = ''): boolean {
     const pronouns = PronounChecker.getPronouns(string);
 
+    if (pronouns.length == 0){
+      return false; 
+    }
+    
     for (const pronoun of pronouns) {
       if (!this.validPronouns.find((validPronoun) => validPronoun === pronoun))
         return false;


### PR DESCRIPTION
Testgevallen en fix toegevoegd. #6 

Check toegevoegd óf er überhaupt wel pronouns in de naam zitten. Geen pronouns wordt hiermee gelijk aan invalide pronouns. Ook verkeerd geformateerde pronouns worden nu niet herkend als goed in de meeste gevallen. 

Voor deze commit worden alleen juist geformateerde, maar ongeldige pronouns herkend.