### PR TITLE
Realisatie nieuw commando om afkortingen te tonen

### DIFF
--- a/apps/discordbot/src/discord/command/abbreviation-command/abbreviation-command.service.spec.ts
+++ b/apps/discordbot/src/discord/command/abbreviation-command/abbreviation-command.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AbbreviationCommandService } from './abbreviation-command.service';
+
+describe('AbbreviationCommandService', () => {
+  let service: AbbreviationCommandService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AbbreviationCommandService],
+    }).compile();
+
+    service = module.get<AbbreviationCommandService>(
+      AbbreviationCommandService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/discordbot/src/discord/command/abbreviation-command/abbreviation-command.service.ts
+++ b/apps/discordbot/src/discord/command/abbreviation-command/abbreviation-command.service.ts
@@ -1,0 +1,32 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { Injectable } from '@nestjs/common';
+import {
+  CommandInteraction,
+  CacheType,
+  ChatInputCommandInteraction,
+} from 'discord.js';
+import { Command } from '../command';
+
+@Injectable()
+export class AbbreviationCommandService extends Command {
+  public COMMAND_NAME = 'abbreviation';
+
+  public setup(): SlashCommandBuilder {
+    return new SlashCommandBuilder()
+      .setName('abbreviation')
+      .setDescription('Toon de lijst met afkortingen.')
+      .setDefaultPermission(true);
+  }
+
+  public async handleCommand(
+    interaction: ChatInputCommandInteraction<CacheType>,
+  ): Promise<void> {
+    await interaction.deferReply();
+
+    await interaction.editReply({
+      files: [
+        'https://static.jonasclaes.be/botivater-resources/afkortingen.jpg',
+      ],
+    });
+  }
+}

--- a/apps/discordbot/src/discord/command/abbreviation-command/abbreviation-command.service.ts
+++ b/apps/discordbot/src/discord/command/abbreviation-command/abbreviation-command.service.ts
@@ -13,7 +13,7 @@ export class AbbreviationCommandService extends Command {
 
   public setup(): SlashCommandBuilder {
     return new SlashCommandBuilder()
-      .setName('abbreviation')
+      .setName(this.COMMAND_NAME)
       .setDescription('Toon de lijst met afkortingen.')
       .setDefaultPermission(true);
   }

--- a/apps/discordbot/src/discord/command/command.service.ts
+++ b/apps/discordbot/src/discord/command/command.service.ts
@@ -20,6 +20,7 @@ import { CommandList } from '@common/common/commandList/commandList.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DevCommandService } from './dev-command/dev-command.service';
 import { ToneIndicatorCommandService } from './tone-indicator-command/tone-indicator-command.service';
+import { AbbreviationCommandService } from './abbreviation-command/abbreviation-command.service';
 import { FindAFriendCommandService } from './find-a-friend-command/find-a-friend-command.service';
 import { HelpCommandService } from './help-command/help-command.service';
 import { SetBirthdayCommandService } from './set-birthday-command/set-birthday-command.service';
@@ -53,6 +54,7 @@ export class CommandService {
     private readonly pingCommandService: PingCommandService,
     private readonly devCommandService: DevCommandService,
     private readonly toneIndicatorCommandService: ToneIndicatorCommandService,
+    private readonly abbreviationCommandService: AbbreviationCommandService,
     private readonly findAFriendCommandService: FindAFriendCommandService,
     private readonly helpCommandService: HelpCommandService,
     private readonly setBirthdayCommandService: SetBirthdayCommandService,
@@ -72,6 +74,7 @@ export class CommandService {
     this.commandArray.push(this.pingCommandService);
     this.commandArray.push(this.devCommandService);
     this.commandArray.push(this.toneIndicatorCommandService);
+    this.commandArray.push(this.abbreviationCommandService);
     this.commandArray.push(this.findAFriendCommandService);
     this.commandArray.push(this.helpCommandService);
     this.commandArray.push(this.setBirthdayCommandService);

--- a/apps/discordbot/src/discord/command/tone-indicator-command/tone-indicator-command.service.ts
+++ b/apps/discordbot/src/discord/command/tone-indicator-command/tone-indicator-command.service.ts
@@ -13,7 +13,7 @@ export class ToneIndicatorCommandService extends Command {
 
   public setup(): SlashCommandBuilder {
     return new SlashCommandBuilder()
-      .setName('toneindicator')
+      .setName(this.COMMAND_NAME)
       .setDescription('Toon de lijst met tone indicators.')
       .setDefaultPermission(true);
   }

--- a/apps/discordbot/src/discord/discord.module.ts
+++ b/apps/discordbot/src/discord/discord.module.ts
@@ -18,6 +18,7 @@ import { PingCommandService } from './command/ping-command/ping-command.service'
 import { CommandList } from '@common/common/commandList/commandList.entity';
 import { DevCommandService } from './command/dev-command/dev-command.service';
 import { ToneIndicatorCommandService } from './command/tone-indicator-command/tone-indicator-command.service';
+import { AbbreviationCommandService } from './command/abbreviation-command/abbreviation-command.service';
 import { FindAFriendCommandService } from './command/find-a-friend-command/find-a-friend-command.service';
 import { HelpCommandService } from './command/help-command/help-command.service';
 import { SetBirthdayCommandService } from './command/set-birthday-command/set-birthday-command.service';
@@ -106,6 +107,7 @@ const discordFactory: Provider = {
     PingCommandService,
     DevCommandService,
     ToneIndicatorCommandService,
+    AbbreviationCommandService,
     FindAFriendCommandService,
     HelpCommandService,
     SetBirthdayCommandService,


### PR DESCRIPTION
Als het goed is zijn dit alle benodigde aanpassingen in de source om de file https://static.jonasclaes.be/botivater-resources/afkortingen.jpg (nog niet geupload op de server!) te tonen bij gebruik van het commando /abbreviation. In Mira voor de friendship bubble zal dit de alias /afkortingen krijgen via front end.